### PR TITLE
Using secrets to authenticate to GCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ dask-worker-space/
 
 # Local testing notebook
 test.ipynb
+test2.ipynb
 
 # Local temp files
 temp/

--- a/.gitignore
+++ b/.gitignore
@@ -114,5 +114,5 @@ test.ipynb
 # Local temp files
 temp/
 
-# Prefect token
-prefect_cloud_token.txt
+# Prefect secrets
+secrets/

--- a/nl_open_data/flows/cbs/register_statline_bq_flow.py
+++ b/nl_open_data/flows/cbs/register_statline_bq_flow.py
@@ -13,9 +13,9 @@ from nl_open_data.config import config
 
 from datetime import datetime
 
-# from box import Box
 from prefect import task, Flow, unmapped, Parameter
 from prefect.executors import DaskExecutor
+from prefect.client import Secret
 from statline_bq.utils import (
     check_gcp_env,
     check_v4,
@@ -90,6 +90,7 @@ with Flow("statline-bq") as statline_flow:
     gcp_env = Parameter("gcp_env", default="dev")
     force = Parameter("force", default=False)
 
+    gcp_credentials = Secret("GCP_CREDENTIALS").get()
     ids = upper.map(
         ids
     )  # TODO: Do we need a different variable name here (ids_upper = ...)?
@@ -192,6 +193,8 @@ with Flow("statline-bq") as statline_flow:
 if __name__ == "__main__":
     # Register flow
     statline_flow.executor = DaskExecutor()
+    print("Output last registration")
+    print("------------------------")
     flow_id = statline_flow.register(
         project_name="nl_open_data", version_group_id="statline_bq"
     )
@@ -201,10 +204,10 @@ if __name__ == "__main__":
     Output last registration
     ------------------------
     Flow URL: https://cloud.prefect.io/dataverbinders/flow/eef07631-c5d3-4313-9b2c-41b1e8d180a8
-    └── ID: 2dedcace-27ec-42b9-8be7-dcdd954078e4
+    └── ID: 36aed3bf-d5ad-4863-903f-08075b77b052
     └── Project: nl_open_data
     └── Labels: ['tud0029822']
-    └── Registered on: 2021-01-12 14:52:31.387941
+    └── Registered on: 2021-01-21 16:59:49.649501
     """
 
     # Run locally

--- a/nl_open_data/flows/cbs/register_temp_secrets.py
+++ b/nl_open_data/flows/cbs/register_temp_secrets.py
@@ -1,0 +1,16 @@
+from nl_open_data.config import config
+from prefect import Flow, task, Parameter
+
+from nl_open_data.utils import check_bq_dataset, get_gcp_credentials
+
+check_bq_dataset = task(check_bq_dataset)
+get_gcp_credentials = task(get_gcp_credentials)
+
+with Flow("test_secret") as flow:
+    json_acct_info = Parameter("json_acct_info")
+    gcp_credentials = get_gcp_credentials(json_acct_info)
+    check_bq_dataset(
+        dataset_id="83583NED", gcp=config.gcp.dev, credentials=gcp_credentials
+    )
+
+flow.register("nl_open_data", version_group_id="test_secrets")

--- a/nl_open_data/flows/cbs/register_temp_secrets.py
+++ b/nl_open_data/flows/cbs/register_temp_secrets.py
@@ -6,9 +6,9 @@ from nl_open_data.utils import check_bq_dataset, get_gcp_credentials
 check_bq_dataset = task(check_bq_dataset)
 get_gcp_credentials = task(get_gcp_credentials)
 
-with Flow("test_secret") as flow:
-    json_acct_info = Parameter("json_acct_info")
-    gcp_credentials = get_gcp_credentials(json_acct_info)
+with Flow("test_secrets") as flow:
+    service_account_info = Parameter("service_account_info")
+    gcp_credentials = get_gcp_credentials(service_account_info)
     check_bq_dataset(
         dataset_id="83583NED", gcp=config.gcp.dev, credentials=gcp_credentials
     )

--- a/nl_open_data/flows/cbs/register_temp_secrets.py
+++ b/nl_open_data/flows/cbs/register_temp_secrets.py
@@ -1,10 +1,10 @@
 from nl_open_data.config import config
 from prefect import Flow, task, Parameter
 
-from nl_open_data.utils import check_bq_dataset, get_gcp_credentials
+from nl_open_data.utils import check_bq_dataset
+from nl_open_data.tasks import get_gcp_credentials
 
 check_bq_dataset = task(check_bq_dataset)
-get_gcp_credentials = task(get_gcp_credentials)
 
 with Flow("test_secrets") as flow:
     service_account_info = Parameter("service_account_info")

--- a/nl_open_data/flows/cbs/register_zip_csv_flow.py
+++ b/nl_open_data/flows/cbs/register_zip_csv_flow.py
@@ -57,6 +57,9 @@ with Flow("zipped_csv") as zip_flow:
         "bq_dataset_description", default=None
     )  # TODO: implement
     source = Parameter("source", required=False)
+    service_account_info = Parameter("service_account_info")
+
+    gcp_credentials = nlt.get_gcp_credentials(service_account_info)
 
     filename = nlt.get_filename_from_url(url)
     filepath = local_folder / nlt.path_wrap(filename)
@@ -74,6 +77,7 @@ with Flow("zipped_csv") as zip_flow:
         gcs_folder=unmapped(gcs_folder),
         config=unmapped(config),
         gcp_env=unmapped(gcp_env),
+        credentials=unmapped(gcp_credentials),
         upstream_tasks=[pq_files],
     )
     tables = nlt.gcs_to_bq(
@@ -82,6 +86,7 @@ with Flow("zipped_csv") as zip_flow:
         config=config,
         gcp_env=gcp_env,
         source=source,
+        credentials=unmapped(gcp_credentials),
         description=bq_dataset_description,
         upstream_tasks=[gcs_ids],
     )
@@ -102,8 +107,8 @@ Output last registration
 ------------------------
 Result check: OK
 Flow URL: https://cloud.prefect.io/dataverbinders/flow/24e3c567-88c7-4a6e-8333-72a9cd1abebd
- └── ID: b91257e3-7c63-468c-9460-c7403e602a0a
+ └── ID: dfe6b519-e20d-4de8-8188-8bf195168d83
  └── Project: nl_open_data
  └── Labels: ['tud0029822']
- └── Registered on: 2021-01-12 18:27:56.586313
+ └── Registered on: 2021-01-26 12:58:09.831253
     """

--- a/nl_open_data/flows/cbs/run_mlz.py
+++ b/nl_open_data/flows/cbs/run_mlz.py
@@ -4,8 +4,11 @@ TODO: Add docstring?
 
 [^mlz]: https://mlzopendata.cbs.nl/#/MLZ/nl/
 """
+# the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
+
 from prefect import Client
+from prefect.client import Secret
 
 VERSION_GROUP_ID = "statline_bq"
 
@@ -15,6 +18,7 @@ SOURCE = "mlz"
 THIRD_PARTY = True
 GCP_ENV = "dev"
 FORCE = False
+SERVICE_ACCOUNT_INFO = Secret("GCP_CREDENTIALS").get()
 
 client = Client()  # Local api key has been stored previously
 client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
@@ -24,6 +28,7 @@ parameters = {
     "third_party": THIRD_PARTY,
     "gcp_env": GCP_ENV,
     "force": FORCE,
+    "service_account_info": SERVICE_ACCOUNT_INFO,
 }
 flow_run_id = client.create_flow_run(
     version_group_id=VERSION_GROUP_ID, parameters=parameters

--- a/nl_open_data/flows/cbs/run_regionaal.py
+++ b/nl_open_data/flows/cbs/run_regionaal.py
@@ -56,9 +56,9 @@ statline_parameters = {
     "gcp_env": GCP_ENV,
     "force": FORCE,
 }
-# flow_run_id = client.create_flow_run(
-#     version_group_id=STATLINE_VERSION_GROUP_ID, parameters=statline_parameters
-# )
+flow_run_id = client.create_flow_run(
+    version_group_id=STATLINE_VERSION_GROUP_ID, parameters=statline_parameters
+)
 
 ####################
 

--- a/nl_open_data/flows/cbs/run_regionaal.py
+++ b/nl_open_data/flows/cbs/run_regionaal.py
@@ -9,8 +9,11 @@ TODO: Add docstring
 """
 from pathlib import Path
 
+# the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
+
 from prefect import Client
+from prefect.client import Secret
 
 STATLINE_VERSION_GROUP_ID = "statline_bq"
 ZIP_VERSION_GROUP_ID = "zipped_csv"
@@ -18,7 +21,7 @@ ZIP_VERSION_GROUP_ID = "zipped_csv"
 TENANT_SLUG = "dataverbinders"
 ODATA_REGIONAAL = [  # TODO: check datasets, add and organize
     # Regionale kerncijfers Nederland
-    "70072NED"
+    "70072NED",
     # Kerncijfers wijken en buurten
     "84583NED",  # 2019
     "84286NED",  # 2018
@@ -44,6 +47,7 @@ SOURCE = "cbs"
 THIRD_PARTY = False
 GCP_ENV = "dev"
 FORCE = False
+SERVICE_ACCOUNT_INFO = Secret("GCP_CREDENTIALS").get()
 
 client = Client()  # Local api key has been stored previously
 client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
@@ -55,6 +59,7 @@ statline_parameters = {
     "third_party": THIRD_PARTY,
     "gcp_env": GCP_ENV,
     "force": FORCE,
+    "service_account_info": SERVICE_ACCOUNT_INFO,
 }
 flow_run_id = client.create_flow_run(
     version_group_id=STATLINE_VERSION_GROUP_ID, parameters=statline_parameters
@@ -82,6 +87,7 @@ zip_parameters = {
     "bq_dataset_name": BQ_DATASET_NAME,
     "bq_dataset_description": BQ_DATASET_DESCRIPTION,
     "source": SOURCE,
+    "service_account_info": SERVICE_ACCOUNT_INFO,
 }
 
 flow_run_id = client.create_flow_run(

--- a/nl_open_data/flows/cbs/run_rivm.py
+++ b/nl_open_data/flows/cbs/run_rivm.py
@@ -4,8 +4,11 @@ TODO: Add docstring?
 
 [^rivm]: https://statline.rivm.nl/#/RIVM/nl/dataset/50052NED/table?ts=1589622516137
 """
+# the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
+
 from prefect import Client
+from prefect.client import Secret
 
 VERSION_GROUP_ID = "statline_bq"
 
@@ -17,6 +20,7 @@ SOURCE = "rivm"  # TODO: VERIFY SOURCE??
 THIRD_PARTY = True
 GCP_ENV = "dev"
 FORCE = False
+SERVICE_ACCOUNT_INFO = Secret("GCP_CREDENTIALS").get()
 
 client = Client()  # Local api key has been stored previously
 client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
@@ -26,6 +30,7 @@ parameters = {
     "third_party": THIRD_PARTY,
     "gcp_env": GCP_ENV,
     "force": FORCE,
+    "service_account_info": SERVICE_ACCOUNT_INFO,
 }
 flow_run_id = client.create_flow_run(
     version_group_id=VERSION_GROUP_ID, parameters=parameters

--- a/nl_open_data/flows/cbs/run_temp_secrets.py
+++ b/nl_open_data/flows/cbs/run_temp_secrets.py
@@ -4,11 +4,12 @@ from prefect import Client
 from prefect.client import Secret
 
 TENANT_SLUG = "dataverbinders"
-JSON_ACCT_INFO = Secret("GCP_CREDENTIALS").get()
+GCP_SERVICE_ACCOUNT_INFO = Secret("GCP_CREDENTIALS").get()
 
 client = Client()  # Local api key has been stored previously
 client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
 
 client.create_flow_run(
-    version_group_id="test_secrets", parameters={"json_acct_info": JSON_ACCT_INFO},
+    version_group_id="test_secrets",
+    parameters={"service_account_info": GCP_SERVICE_ACCOUNT_INFO},
 )

--- a/nl_open_data/flows/cbs/run_temp_secrets.py
+++ b/nl_open_data/flows/cbs/run_temp_secrets.py
@@ -1,0 +1,14 @@
+from nl_open_data.config import config
+
+from prefect import Client
+from prefect.client import Secret
+
+TENANT_SLUG = "dataverbinders"
+JSON_ACCT_INFO = Secret("GCP_CREDENTIALS").get()
+
+client = Client()  # Local api key has been stored previously
+client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
+
+client.create_flow_run(
+    version_group_id="test_secrets", parameters={"json_acct_info": JSON_ACCT_INFO},
+)

--- a/nl_open_data/user_config.toml
+++ b/nl_open_data/user_config.toml
@@ -1,3 +1,6 @@
+[cloud]
+use_local_secrets = false
+
 [gcp]
     [gcp.prod]
     project_id = "dataverbinders"

--- a/nl_open_data/utils.py
+++ b/nl_open_data/utils.py
@@ -4,8 +4,14 @@ from pathlib import Path
 from google.cloud import storage
 from google.cloud import bigquery
 from google.cloud import exceptions
+from google.oauth2 import service_account
 
 from statline_bq.config import Config, GcpProject
+
+
+def get_gcp_credentials(json_acct_info):
+    credentials = service_account.Credentials.from_service_account_info(json_acct_info)
+    return credentials
 
 
 def create_dir_util(path: Union[Path, str]) -> Path:
@@ -42,7 +48,7 @@ def set_gcp(config: Config, gcp_env: str) -> GcpProject:
     return config_envs[gcp_env]
 
 
-def check_bq_dataset(dataset_id: str, gcp: GcpProject) -> bool:
+def check_bq_dataset(dataset_id: str, gcp: GcpProject, credentials: str = None) -> bool:
     """Check if dataset exists in BQ.
 
     Parameters
@@ -57,7 +63,7 @@ def check_bq_dataset(dataset_id: str, gcp: GcpProject) -> bool:
         - True if exists, False if does not exists
     """
 
-    client = bigquery.Client(project=gcp.project_id)
+    client = bigquery.Client(project=gcp.project_id, credentials=credentials)
 
     try:
         client.get_dataset(dataset_id)  # Make an API request.

--- a/nl_open_data/utils.py
+++ b/nl_open_data/utils.py
@@ -9,8 +9,12 @@ from google.oauth2 import service_account
 from statline_bq.config import Config, GcpProject
 
 
-def get_gcp_credentials(json_acct_info):
-    credentials = service_account.Credentials.from_service_account_info(json_acct_info)
+def get_gcp_credentials(
+    service_account_info,
+):  # ADD TYPE CHECKING service_account_info / Credentials
+    credentials = service_account.Credentials.from_service_account_info(
+        service_account_info
+    )
     return credentials
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -164,6 +164,14 @@ diagnostics = ["bokeh (>=1.0.0,!=2.0.0)"]
 distributed = ["distributed (>=2.0)"]
 
 [[package]]
+name = "dataclasses"
+version = "0.6"
+description = "A backport of the dataclasses module for Python 3.6"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "dataclasses-json"
 version = "0.5.2"
 description = "Easily serialize dataclasses to and from JSON"
@@ -984,13 +992,14 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pyserde"
-version = "0.2.1"
+version = "0.2.2"
 description = "Serialization library on top of dataclasses."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
+dataclasses = "*"
 jinja2 = "*"
 stringcase = "*"
 toml = {version = "*", optional = true, markers = "extra == \"toml\""}
@@ -1164,12 +1173,12 @@ python-versions = "*"
 
 [[package]]
 name = "statline-bq"
-version = "0.1.0"
+version = "0.1.2"
 description = "Library to upload CBS open datasets into Google Cloud Platform"
 category = "main"
 optional = false
 python-versions = "^3.8"
-develop = true
+develop = false
 
 [package.dependencies]
 click = "^7.1.2"
@@ -1179,7 +1188,6 @@ google-auth = "^1.19.2"
 google-cloud-bigquery = "^1.26.1"
 google-cloud-core = "^1.3.0"
 google-cloud-storage = "^1.30.0"
-prefect = "^0.14.0"
 pyarrow = "^2.0.0"
 pyserde = {version = "^0.2.0", extras = ["toml"]}
 requests = "^2.24.0"
@@ -1187,8 +1195,10 @@ toml = "^0.10.2"
 tomlkit = "^0.7.0"
 
 [package.source]
-type = "directory"
-url = "../statline-bq"
+type = "git"
+url = "https://github.com/dataverbinders/statline-bq.git"
+reference = "main"
+resolved_reference = "7dcfcfd863318e03cc09b0cbd9efe2ce39c41a4d"
 
 [[package]]
 name = "stringcase"
@@ -1353,7 +1363,7 @@ heapdict = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "b688a6d27422e61af316320c27625b6f42125ff0f8948e512712a08551c268a8"
+content-hash = "ef5abb95089d94a459ea35a4ab4428eb926fae8da8e4f6300ace344e931415e3"
 
 [metadata.files]
 appdirs = [
@@ -1451,6 +1461,10 @@ croniter = [
 dask = [
     {file = "dask-2.30.0-py3-none-any.whl", hash = "sha256:4c215aa55951f570b5a294b2ce964ed801c6efd766231c53447460e60f73ea14"},
     {file = "dask-2.30.0.tar.gz", hash = "sha256:a1669022e25de99b227c3d83da4801f032415962dac431099bf0534648e41a54"},
+]
+dataclasses = [
+    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
+    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
 ]
 dataclasses-json = [
     {file = "dataclasses-json-0.5.2.tar.gz", hash = "sha256:56ec931959ede74b5dedf65cf20772e6a79764d20c404794cce0111c88c085ff"},
@@ -1961,8 +1975,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pyserde = [
-    {file = "pyserde-0.2.1-py3-none-any.whl", hash = "sha256:891289d8b2eb67fb202ec2cccb817c9c188497a83bc21d9c0db969108048d9aa"},
-    {file = "pyserde-0.2.1.tar.gz", hash = "sha256:7b4cb6b4a5c806d65ab260664357620e72ef680604f9f541e1ab7c24b777863a"},
+    {file = "pyserde-0.2.2-py3-none-any.whl", hash = "sha256:bef911d6223c7aa4ad697b791e99d01b871a972876eb2cc01aad9a80f8debb4a"},
+    {file = "pyserde-0.2.2.tar.gz", hash = "sha256:a132e8ffef59ac8be6012c6df5ddf13d53f8cc110bb920cb0530f339f0527423"},
 ]
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ statline_bq = {git = "https://github.com/dataverbinders/statline-bq.git", branch
 # statline_bq = {path = "/Users/tslilstrauss/Projects/statline-bq", develop = true} # takes statline-bq from a local path
 pandas = "^1.1.5"
 python-box = "^5.2.0"
+dask = "^2.21.0"
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ pyarrow = "^2.0.0"
 bunch = "^1.0.1"
 lxml = "^4.5.2"
 xmltodict = "^0.12.0"
-# statline_bq = {git = "https://github.com/dataverbinders/statline-bq.git", branch = "main"} # takes main branch of statline-bq from github
-statline_bq = {path = "/Users/tslilstrauss/Projects/statline-bq", develop = true} # takes statline-bq from a local path
+statline_bq = {git = "https://github.com/dataverbinders/statline-bq.git", branch = "main"} # takes main branch of statline-bq from github
+# statline_bq = {path = "/Users/tslilstrauss/Projects/statline-bq", develop = true} # takes statline-bq from a local path
 pandas = "^1.1.5"
 python-box = "^5.2.0"
 


### PR DESCRIPTION
@dkapitan 
Authenticating to GCP using Secrets is functional, using either a local or a remote machine. **But....** it is not actually needed.

By [assigning the service account](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances) to the VM instance, all authentication to GCP APIs is defaulted to that service account.

I suggest to leave this unmerged, and return to it if needed.

