### PR TITLE
Cbs external flows

### DIFF
--- a/nl_open_data/flows/run/cbs/run_azw.py
+++ b/nl_open_data/flows/run/cbs/run_azw.py
@@ -1,8 +1,7 @@
-"""Use statline-bq flow to all MLZ datasets to GBQ
+"""Use statline-bq flow to all AZW datasets to GBQ
 
 TODO: Add docstring?
 
-[^mlz]: https://mlzopendata.cbs.nl/#/MLZ/nl/
 """
 ## the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
@@ -16,12 +15,12 @@ from nl_open_data.utils import query_cbs_catalogs
 TENANT_SLUG = "dataverbinders"
 
 # flow parameters
-SOURCE = "mlz"
+SOURCE = "iv3"
 THIRD_PARTY = True
 GCP_ENV = "prod"
 FORCE = False
 CONFIG = config
-ODATA_MLZ = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
+ODATA_IV3 = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
 
 # run parameters
 VERSION_GROUP_ID = "statline_bq"
@@ -31,7 +30,7 @@ if __name__ == "__main__":
     prefect_client = PrefectClient()  # Local api key has been stored previously
     prefect_client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
     parameters = {
-        "ids": ODATA_MLZ,
+        "ids": ODATA_IV3,
         "source": SOURCE,
         "third_party": THIRD_PARTY,
         # "config": CONFIG, #BUG

--- a/nl_open_data/flows/run/cbs/run_interreg.py
+++ b/nl_open_data/flows/run/cbs/run_interreg.py
@@ -1,8 +1,7 @@
-"""Use statline-bq flow to all MLZ datasets to GBQ
+"""Use statline-bq flow to all INTERREG datasets to GBQ
 
 TODO: Add docstring?
 
-[^mlz]: https://mlzopendata.cbs.nl/#/MLZ/nl/
 """
 ## the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
@@ -16,12 +15,12 @@ from nl_open_data.utils import query_cbs_catalogs
 TENANT_SLUG = "dataverbinders"
 
 # flow parameters
-SOURCE = "mlz"
+SOURCE = "interreg"
 THIRD_PARTY = True
 GCP_ENV = "prod"
 FORCE = False
 CONFIG = config
-ODATA_MLZ = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
+ODATA_IV3 = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
 
 # run parameters
 VERSION_GROUP_ID = "statline_bq"
@@ -31,7 +30,7 @@ if __name__ == "__main__":
     prefect_client = PrefectClient()  # Local api key has been stored previously
     prefect_client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
     parameters = {
-        "ids": ODATA_MLZ,
+        "ids": ODATA_IV3,
         "source": SOURCE,
         "third_party": THIRD_PARTY,
         # "config": CONFIG, #BUG

--- a/nl_open_data/flows/run/cbs/run_iv3.py
+++ b/nl_open_data/flows/run/cbs/run_iv3.py
@@ -1,8 +1,7 @@
-"""Use statline-bq flow to all MLZ datasets to GBQ
+"""Use statline-bq flow to all IV3 datasets to GBQ
 
 TODO: Add docstring?
 
-[^mlz]: https://mlzopendata.cbs.nl/#/MLZ/nl/
 """
 ## the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
@@ -16,12 +15,12 @@ from nl_open_data.utils import query_cbs_catalogs
 TENANT_SLUG = "dataverbinders"
 
 # flow parameters
-SOURCE = "mlz"
+SOURCE = "iv3"
 THIRD_PARTY = True
 GCP_ENV = "prod"
 FORCE = False
 CONFIG = config
-ODATA_MLZ = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
+ODATA_IV3 = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
 
 # run parameters
 VERSION_GROUP_ID = "statline_bq"
@@ -31,7 +30,7 @@ if __name__ == "__main__":
     prefect_client = PrefectClient()  # Local api key has been stored previously
     prefect_client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
     parameters = {
-        "ids": ODATA_MLZ,
+        "ids": ODATA_IV3,
         "source": SOURCE,
         "third_party": THIRD_PARTY,
         # "config": CONFIG, #BUG

--- a/nl_open_data/flows/run/cbs/run_jm.py
+++ b/nl_open_data/flows/run/cbs/run_jm.py
@@ -1,8 +1,7 @@
-"""Use statline-bq flow to all MLZ datasets to GBQ
+"""Use statline-bq flow to all JM datasets to GBQ
 
 TODO: Add docstring?
 
-[^mlz]: https://mlzopendata.cbs.nl/#/MLZ/nl/
 """
 ## the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
@@ -16,12 +15,12 @@ from nl_open_data.utils import query_cbs_catalogs
 TENANT_SLUG = "dataverbinders"
 
 # flow parameters
-SOURCE = "mlz"
+SOURCE = "jm"
 THIRD_PARTY = True
 GCP_ENV = "prod"
 FORCE = False
 CONFIG = config
-ODATA_MLZ = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
+ODATA_IV3 = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
 
 # run parameters
 VERSION_GROUP_ID = "statline_bq"
@@ -31,7 +30,7 @@ if __name__ == "__main__":
     prefect_client = PrefectClient()  # Local api key has been stored previously
     prefect_client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
     parameters = {
-        "ids": ODATA_MLZ,
+        "ids": ODATA_IV3,
         "source": SOURCE,
         "third_party": THIRD_PARTY,
         # "config": CONFIG, #BUG

--- a/nl_open_data/flows/run/cbs/run_mkb.py
+++ b/nl_open_data/flows/run/cbs/run_mkb.py
@@ -1,8 +1,7 @@
-"""Use statline-bq flow to all MLZ datasets to GBQ
+"""Use statline-bq flow to all MKB datasets to GBQ
 
 TODO: Add docstring?
 
-[^mlz]: https://mlzopendata.cbs.nl/#/MLZ/nl/
 """
 ## the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
@@ -16,12 +15,12 @@ from nl_open_data.utils import query_cbs_catalogs
 TENANT_SLUG = "dataverbinders"
 
 # flow parameters
-SOURCE = "mlz"
+SOURCE = "azw"
 THIRD_PARTY = True
 GCP_ENV = "prod"
 FORCE = False
 CONFIG = config
-ODATA_MLZ = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
+ODATA_IV3 = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
 
 # run parameters
 VERSION_GROUP_ID = "statline_bq"
@@ -31,7 +30,7 @@ if __name__ == "__main__":
     prefect_client = PrefectClient()  # Local api key has been stored previously
     prefect_client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
     parameters = {
-        "ids": ODATA_MLZ,
+        "ids": ODATA_IV3,
         "source": SOURCE,
         "third_party": THIRD_PARTY,
         # "config": CONFIG, #BUG

--- a/nl_open_data/flows/run/cbs/run_mvstat.py
+++ b/nl_open_data/flows/run/cbs/run_mvstat.py
@@ -1,8 +1,7 @@
-"""Use statline-bq flow to all MLZ datasets to GBQ
+"""Use statline-bq flow to all MVSTAT datasets to GBQ
 
 TODO: Add docstring?
 
-[^mlz]: https://mlzopendata.cbs.nl/#/MLZ/nl/
 """
 ## the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
@@ -16,12 +15,12 @@ from nl_open_data.utils import query_cbs_catalogs
 TENANT_SLUG = "dataverbinders"
 
 # flow parameters
-SOURCE = "mlz"
+SOURCE = "mvstat"
 THIRD_PARTY = True
 GCP_ENV = "prod"
 FORCE = False
 CONFIG = config
-ODATA_MLZ = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
+ODATA_IV3 = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
 
 # run parameters
 VERSION_GROUP_ID = "statline_bq"
@@ -31,7 +30,7 @@ if __name__ == "__main__":
     prefect_client = PrefectClient()  # Local api key has been stored previously
     prefect_client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
     parameters = {
-        "ids": ODATA_MLZ,
+        "ids": ODATA_IV3,
         "source": SOURCE,
         "third_party": THIRD_PARTY,
         # "config": CONFIG, #BUG

--- a/nl_open_data/flows/run/cbs/run_politie.py
+++ b/nl_open_data/flows/run/cbs/run_politie.py
@@ -1,8 +1,7 @@
-"""Use statline-bq flow to all MLZ datasets to GBQ
+"""Use statline-bq flow to all politie datasets to GBQ
 
 TODO: Add docstring?
 
-[^mlz]: https://mlzopendata.cbs.nl/#/MLZ/nl/
 """
 ## the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
@@ -16,12 +15,12 @@ from nl_open_data.utils import query_cbs_catalogs
 TENANT_SLUG = "dataverbinders"
 
 # flow parameters
-SOURCE = "mlz"
+SOURCE = "politie"
 THIRD_PARTY = True
 GCP_ENV = "prod"
 FORCE = False
 CONFIG = config
-ODATA_MLZ = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
+ODATA_IV3 = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
 
 # run parameters
 VERSION_GROUP_ID = "statline_bq"
@@ -31,7 +30,7 @@ if __name__ == "__main__":
     prefect_client = PrefectClient()  # Local api key has been stored previously
     prefect_client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token
     parameters = {
-        "ids": ODATA_MLZ,
+        "ids": ODATA_IV3,
         "source": SOURCE,
         "third_party": THIRD_PARTY,
         # "config": CONFIG, #BUG

--- a/nl_open_data/flows/run/cbs/run_rivm.py
+++ b/nl_open_data/flows/run/cbs/run_rivm.py
@@ -25,7 +25,7 @@ ODATA_RIVM = query_cbs_catalogs(third_party=THIRD_PARTY, source=SOURCE)[SOURCE]
 
 # run parameters
 VERSION_GROUP_ID = "statline_bq"
-RUN_NAME = f"rivm_{datetime.today().date()}_{datetime.today().time()}"
+RUN_NAME = f"{SOURCE}_{datetime.today().date()}_{datetime.today().time()}"
 
 client = Client()  # Local api key has been stored previously
 client.login_to_tenant(tenant_slug=TENANT_SLUG)  # For user-scoped API token

--- a/nl_open_data/flows/run/cbs/run_test_statline_bq_flow.py
+++ b/nl_open_data/flows/run/cbs/run_test_statline_bq_flow.py
@@ -1,3 +1,5 @@
+"""A run script to test statline_bq_flow
+"""
 # the config object must be imported from config.py before any Prefect imports
 from nl_open_data.config import config
 
@@ -10,9 +12,6 @@ from prefect import Client as PrefectClient
 # Prefect client parameters
 TENANT_SLUG = "dataverbinders"
 
-# # dask parameters
-# IP = "127.0.0.1:8888"
-
 # flow parameters
 DATA = ["83583NED"]
 # DATA = ["83583NED", "83765NED"]
@@ -20,7 +19,7 @@ DATA = ["83583NED"]
 SOURCE = "cbs"
 THIRD_PARTY = False
 GCP_ENV = "dev"
-FORCE = True
+FORCE = False
 # BUG: If config is provided here, it becomes a dict somewhere along the process and an error occurs when using dot notation.
 # When provided as a default in the Register script, the issue doe not occur.
 # Generally this seems like the wrong way to go about it anyway - we provide the full prefect config via a parameter, just because we add our config to it.

--- a/nl_open_data/tasks.py
+++ b/nl_open_data/tasks.py
@@ -107,10 +107,11 @@ def clean_file_name(file: Union[str, Path], chars: str = None) -> Path:
 
 @task
 def remove_dir(path: Union[str, Path]) -> None:
-    try:
-        rmtree(Path(path))
-    except FileNotFoundError:
-        pass
+    if path:
+        try:
+            rmtree(Path(path))
+        except FileNotFoundError:
+            pass
     return None
 
 

--- a/nl_open_data/utils.py
+++ b/nl_open_data/utils.py
@@ -298,7 +298,7 @@ def query_cbs_catalogs(
         """
     if source:
         where_string = f"""
-            WHERE LOWER(Catalog)={source.lower()}
+            WHERE LOWER(Catalog)='{source.lower()}'
         """
     else:
         where_string = ""
@@ -317,6 +317,6 @@ def query_cbs_catalogs(
 
     ids = {}
     for source in sources_set:
-        ids[source] = [k for k, v in datasets.items() if v == source]
+        ids[source.lower()] = [k for k, v in datasets.items() if v == source]
 
     return ids

--- a/poetry.lock
+++ b/poetry.lock
@@ -1325,7 +1325,7 @@ tomlkit = "^0.7.0"
 type = "git"
 url = "https://github.com/dataverbinders/statline-bq.git"
 reference = "master"
-resolved_reference = "09affb5621a416b21d9c537e380188bc53573c72"
+resolved_reference = "d27a11b939938e29c97a78361d65918e6d7f2ec0"
 
 [[package]]
 name = "stringcase"
@@ -1503,7 +1503,7 @@ heapdict = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "9f95380b7a4e4cd47ebc398390f77afe77c75a35570b0496927e12e1ad91aceb"
+content-hash = "69fa0645c4df4c133ca8976b2e01fc6f96441135457242b1a35dc605e9a6154e"
 
 [metadata.files]
 altair = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dataclasses-json = "^0.5.2"
 bokeh = "^2.2.3"
 altair = "^4.1.0"
 cbsodata = "^1.3.4"
+tomlkit = "^0.7.0"
 
 
 [tool.dephell.main]


### PR DESCRIPTION
## This PR:
### Conceptually
* Adds various `run` scripts - one per external source from the CBS external catalog,  each uploading their respective datasets from the CBS external catalog.
* Conforms existing external CBS `run` scripts.
* Fixes minor bugs.

### Technically
* Updates:
  * The following `run_flow` files:
    * `mlz` and `rivm`, with minor modifications.
  * `utils`:
    * Bug fix in `query_cbs_catalogs`
  * `tasks`:
    * Bug fix in `remove_dir` for skipped datasets.
* Adds:
  * The following `run_flow` files:
    * `azw`, `interreg`, `iv3`, `jm`, `mkb`, `mvstat`, `politie` - each uploading their their respective datasets from the CBS external catalog.