### PR TITLE
Box config

### DIFF
--- a/nl_open_data/config.py
+++ b/nl_open_data/config.py
@@ -2,10 +2,16 @@ import os
 from pathlib import Path
 from importlib import import_module
 
+import toml
+from box import Box
+
 CONFIG_TOML = "user_config.toml"
 config_path = Path(__file__).parent / CONFIG_TOML
 
-if config_path.exists():
-    os.environ["PREFECT__USER_CONFIG_PATH"] = config_path.as_posix()
+config = Box(toml.load(config_path))
 
-config = getattr(import_module("prefect"), "config")
+# This can be used to add to prefect contect object
+# if config_path.exists():
+#     os.environ["PREFECT__USER_CONFIG_PATH"] = config_path.as_posix()
+
+# config = getattr(import_module("prefect"), "config")

--- a/nl_open_data/flows/register/register_statline_bq_flow.py
+++ b/nl_open_data/flows/register/register_statline_bq_flow.py
@@ -7,10 +7,6 @@ in 'user_config.toml', which is imported and coupled to the Prefect config objec
 inside 'config.py'. Therefore, anything that is defined in the 'user_config.toml'
 can be accessed by accessing `config`. For example, `config.gcp.dev`.
 """
-
-# the config object must be imported from config.py before any Prefect imports
-from nl_open_data.config import config as CONFIG
-
 from prefect import task, Flow, unmapped, Parameter
 from prefect.run_configs import LocalRun
 from prefect.storage import GCS
@@ -28,6 +24,7 @@ from statline_bq.utils import (
     skip_dataset,
 )
 
+from nl_open_data.config import config as CONFIG
 import nl_open_data.tasks as nlt
 
 # Converting statline-bq functions to tasks
@@ -48,6 +45,7 @@ nlt.remove_dir.trigger = all_finished
 
 VERSION_GROUP_ID = "statline_bq"
 PROJECT_NAME = "nl_open_data"
+
 
 with Flow("statline-bq") as statline_flow:
     """A Prefect flow to upload datasets from CBS Statline to Google BigQuery.

--- a/nl_open_data/flows/run/cbs/run_test_statline_bq_flow.py
+++ b/nl_open_data/flows/run/cbs/run_test_statline_bq_flow.py
@@ -1,11 +1,14 @@
 """A run script to test statline_bq_flow
 """
 # the config object must be imported from config.py before any Prefect imports
-from nl_open_data.config import config
+# from nl_open_data.config import config
 
 from datetime import datetime
+from pathlib import Path
 
 from prefect import Client as PrefectClient
+
+from nl_open_data.config import config
 
 # Schedules a flow-run on prefect cloud
 
@@ -22,9 +25,8 @@ GCP_ENV = "dev"
 FORCE = False
 # BUG: If config is provided here, it becomes a dict somewhere along the process and an error occurs when using dot notation.
 # When provided as a default in the Register script, the issue doe not occur.
-# Generally this seems like the wrong way to go about it anyway - we provide the full prefect config via a parameter, just because we add our config to it.
-# CONFIG = config
-# CONFIG = Box(config)
+CONFIG = config
+
 
 # run parameters
 STATLINE_VERSION_GROUP_ID = "statline_bq"

--- a/nl_open_data/tasks.py
+++ b/nl_open_data/tasks.py
@@ -6,6 +6,7 @@ from tempfile import gettempdir, mkdtemp
 from zipfile import ZipFile
 import requests
 
+from box import Box
 from google.cloud import storage
 import pandas as pd
 from pyarrow import Table as PA_Table
@@ -13,7 +14,6 @@ from pyarrow import csv, concat_tables
 import pyarrow.parquet as pq
 from prefect.engine.signals import SKIP
 from prefect import task
-from statline_bq.config import Config
 
 import nl_open_data.utils as nlu
 
@@ -353,7 +353,7 @@ def struct_to_parquet(struct: list, file_name: str, folder_name: str = None):
 def upload_to_gcs(
     to_upload: Union[str, Path],
     gcs_folder: str,
-    config: Config,
+    config: Box,
     source: str = None,
     gcp_env: str = "dev",
     prod_env: str = None,
@@ -387,7 +387,7 @@ def upload_to_gcs(
 def gcs_folder_to_bq(
     gcs_folder: str,
     dataset_name: str,
-    config: Config = None,
+    config: Box = None,
     source: str = None,
     gcp_env: str = "dev",
     prod_env: str = None,
@@ -441,7 +441,7 @@ def gcs_folder_to_bq(
 def create_linked_dataset(
     dataset_name: str,
     gcs_uris: list,
-    config: Config,
+    config: Box,
     gcp_env: str = "dev",
     prod_env: str = None,
     **kwargs,

--- a/nl_open_data/tasks.py
+++ b/nl_open_data/tasks.py
@@ -64,6 +64,11 @@ def skip_task(x):
 
 
 @task
+def get_wrap(obj, key):
+    return obj.get(key)
+
+
+@task
 def clean_file_name(file: Union[str, Path], chars: str = None) -> Path:
     """Renames files by replacing certain characters from the filename with an underscore.
 

--- a/nl_open_data/utils.py
+++ b/nl_open_data/utils.py
@@ -1,11 +1,10 @@
 from typing import Union, List
 from pathlib import Path
 
+from box import Box
 from google.cloud import storage
 from google.cloud import bigquery
 from google.cloud import exceptions
-
-from statline_bq.config import Config, GcpProject
 
 
 def create_dir_util(path: Union[Path, str]) -> Path:
@@ -32,16 +31,14 @@ def create_dir_util(path: Union[Path, str]) -> Path:
         return None
 
 
-def set_gcp(
-    config: Config, gcp_env: str, source: str = None, prod_env: str = None
-) -> GcpProject:
+def set_gcp(config: Box, gcp_env: str, source: str = None, prod_env: str = None) -> Box:
     # TODO: Complete docstring
     """Sets the desired GCP donciguration
 
     Parameters
     ----------
-    config : Config
-        `statline_bq.config.Config` object
+    config : Box
+        A box object holding configuration
     gcp_env : str
         String representing the desired environment between ['dev', 'test', 'prod']
     source : str
@@ -49,8 +46,7 @@ def set_gcp(
 
     Returns
     -------
-    GcpProject
-        A GcpProject class object holding GCP Project parameters (project id, bucket)
+    A Box object holding GCP Project parameters (project id, bucket)
     """
     config_envs = {
         "dev": config.gcp.dev,
@@ -85,15 +81,15 @@ def set_gcp(
         return config_envs[gcp_env][prod_env]
 
 
-def check_bq_dataset(dataset_id: str, gcp: GcpProject) -> bool:
+def check_bq_dataset(dataset_id: str, gcp: Box) -> bool:
     """Check if dataset exists in BQ.
 
     Parameters
     ----------
         - dataset_id : str
             A BQ dataset id
-        - gcp: GcpProject
-            An `nl_open_data.config.GcpProject` object, holding GCP project parameters
+        - gcp: Box
+            A box object, holding GCP project parameters
 
     Returns
     -------
@@ -109,7 +105,7 @@ def check_bq_dataset(dataset_id: str, gcp: GcpProject) -> bool:
         return False
 
 
-def delete_bq_dataset(dataset_id: str, gcp: GcpProject) -> None:
+def delete_bq_dataset(dataset_id: str, gcp: Box) -> None:
     """Delete an exisiting dataset from Google Big Query.
 
     If dataset does not exists, does nothing.
@@ -118,8 +114,8 @@ def delete_bq_dataset(dataset_id: str, gcp: GcpProject) -> None:
     ----------
         dataset_id : str
             A BQ dataset id
-        gcp : GcpProject
-            An `nl_open_data.config.GcpProject` object, holding GCP project parameters
+        gcp : Box
+            A Box object, holding GCP project parameters
 
     Returns
     -------
@@ -136,7 +132,7 @@ def delete_bq_dataset(dataset_id: str, gcp: GcpProject) -> None:
 
 
 def create_bq_dataset(
-    name: str, gcp: GcpProject, source: str = None, description: str = None,
+    name: str, gcp: Box, source: str = None, description: str = None,
 ) -> str:
     """Creates a dataset in Google Big Query. If dataset exists already exists, does nothing.
 
@@ -144,8 +140,8 @@ def create_bq_dataset(
     ----------
     name : str
         The name of the dataset. If no source is given will be used as dataset_id
-    gcp : GcpProject
-        An `nl_open_data.config.GcpProject` object, holding GCP project parameters
+    gcp : Box
+        A Box object, holding GCP project parameters
     description : str, default = None
         The description of the dataset
     source: str, default = None
@@ -187,7 +183,7 @@ def create_bq_dataset(
         return dataset.dataset_id
 
 
-def link_pq_folder_to_bq_dataset(gcs_folder: str, gcp: GcpProject, dataset_id: str):
+def link_pq_folder_to_bq_dataset(gcs_folder: str, gcp: Box, dataset_id: str):
 
     # Get blobs within gcs_folder
     storage_client = storage.Client(project=gcp.project_id)
@@ -222,14 +218,14 @@ def link_pq_folder_to_bq_dataset(gcs_folder: str, gcp: GcpProject, dataset_id: s
     return tables
 
 
-def create_linked_tables(source_uris: List[str], gcp: GcpProject, dataset_id: str):
+def create_linked_tables(source_uris: List[str], gcp: Box, dataset_id: str):
     """Takes a list of GCS uris and creates a linked table per uri nested under the given dataset_id
 
     Parameters
     ----------
     source_uris : List[str]
         [description]
-    gcp : GcpProject
+    gcp : Box
         [description]
     dataset_id : str
         [description]

--- a/nl_open_data/utils.py
+++ b/nl_open_data/utils.py
@@ -1,7 +1,6 @@
-from typing import Union, List
+from typing import Union, List, Mapping
 from pathlib import Path
 
-from box import Box
 from google.cloud import storage
 from google.cloud import bigquery
 from google.cloud import exceptions
@@ -31,7 +30,9 @@ def create_dir_util(path: Union[Path, str]) -> Path:
         return None
 
 
-def set_gcp(config: Box, gcp_env: str, source: str = None, prod_env: str = None) -> Box:
+def set_gcp(
+    config: Mapping, gcp_env: str, source: str = None, prod_env: str = None
+) -> Mapping:
     # TODO: Complete docstring
     """Sets the desired GCP donciguration
 
@@ -81,7 +82,7 @@ def set_gcp(config: Box, gcp_env: str, source: str = None, prod_env: str = None)
         return config_envs[gcp_env][prod_env]
 
 
-def check_bq_dataset(dataset_id: str, gcp: Box) -> bool:
+def check_bq_dataset(dataset_id: str, gcp: Mapping) -> bool:
     """Check if dataset exists in BQ.
 
     Parameters
@@ -105,7 +106,7 @@ def check_bq_dataset(dataset_id: str, gcp: Box) -> bool:
         return False
 
 
-def delete_bq_dataset(dataset_id: str, gcp: Box) -> None:
+def delete_bq_dataset(dataset_id: str, gcp: Mapping) -> None:
     """Delete an exisiting dataset from Google Big Query.
 
     If dataset does not exists, does nothing.
@@ -132,7 +133,7 @@ def delete_bq_dataset(dataset_id: str, gcp: Box) -> None:
 
 
 def create_bq_dataset(
-    name: str, gcp: Box, source: str = None, description: str = None,
+    name: str, gcp: Mapping, source: str = None, description: str = None,
 ) -> str:
     """Creates a dataset in Google Big Query. If dataset exists already exists, does nothing.
 
@@ -183,7 +184,7 @@ def create_bq_dataset(
         return dataset.dataset_id
 
 
-def link_pq_folder_to_bq_dataset(gcs_folder: str, gcp: Box, dataset_id: str):
+def link_pq_folder_to_bq_dataset(gcs_folder: str, gcp: Mapping, dataset_id: str):
 
     # Get blobs within gcs_folder
     storage_client = storage.Client(project=gcp.project_id)
@@ -218,7 +219,7 @@ def link_pq_folder_to_bq_dataset(gcs_folder: str, gcp: Box, dataset_id: str):
     return tables
 
 
-def create_linked_tables(source_uris: List[str], gcp: Box, dataset_id: str):
+def create_linked_tables(source_uris: List[str], gcp: Mapping, dataset_id: str):
     """Takes a list of GCS uris and creates a linked table per uri nested under the given dataset_id
 
     Parameters

--- a/poetry.lock
+++ b/poetry.lock
@@ -111,7 +111,7 @@ python-versions = "*"
 
 [[package]]
 name = "cachetools"
-version = "4.2.1"
+version = "4.2.2"
 description = "Extensible memoizing collections and decorators"
 category = "main"
 optional = false
@@ -193,7 +193,7 @@ python-dateutil = "*"
 
 [[package]]
 name = "dask"
-version = "2021.4.0"
+version = "2021.4.1"
 description = "Parallel PyData with Task Scheduling"
 category = "main"
 optional = false
@@ -208,23 +208,15 @@ toolz = ">=0.8.2"
 
 [package.extras]
 array = ["numpy (>=1.16)"]
-complete = ["bokeh (>=1.0.0,!=2.0.0)", "distributed (>=2021.03.0)", "numpy (>=1.16)", "pandas (>=0.25.0)"]
+complete = ["bokeh (>=1.0.0,!=2.0.0)", "distributed (>=2021.04.1)", "numpy (>=1.16)", "pandas (>=0.25.0)"]
 dataframe = ["numpy (>=1.16)", "pandas (>=0.25.0)"]
 diagnostics = ["bokeh (>=1.0.0,!=2.0.0)"]
-distributed = ["distributed (>=2021.03.0)"]
+distributed = ["distributed (>=2021.04.1)"]
 test = ["pytest", "pytest-rerunfailures", "pytest-xdist"]
 
 [[package]]
-name = "dataclasses"
-version = "0.6"
-description = "A backport of the dataclasses module for Python 3.6"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "dataclasses-json"
-version = "0.5.2"
+version = "0.5.3"
 description = "Easily serialize dataclasses to and from JSON"
 category = "dev"
 optional = false
@@ -237,7 +229,7 @@ stringcase = "1.2.0"
 typing-inspect = ">=0.4.0"
 
 [package.extras]
-dev = ["pytest", "ipython", "mypy (>=0.710)", "hypothesis", "portray", "flake8", "simplejson"]
+dev = ["pytest (>=6.2.3)", "ipython", "mypy (>=0.710)", "hypothesis", "portray", "flake8", "simplejson"]
 
 [[package]]
 name = "decorator"
@@ -249,7 +241,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "distributed"
-version = "2021.4.0"
+version = "2021.4.1"
 description = "Distributed scheduler for Dask"
 category = "main"
 optional = false
@@ -354,7 +346,7 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2)"]
 
 [[package]]
 name = "google-auth"
-version = "1.29.0"
+version = "1.30.0"
 description = "Google Authentication Library"
 category = "main"
 optional = false
@@ -412,7 +404,7 @@ grpc = ["grpcio (>=1.8.2,<2.0dev)"]
 
 [[package]]
 name = "google-cloud-storage"
-version = "1.37.1"
+version = "1.38.0"
 description = "Google Cloud Storage API client library"
 category = "main"
 optional = false
@@ -573,7 +565,7 @@ testing = ["Django (<3.1)", "colorama", "docopt", "pytest (>=3.9.0,<5.0.0)"]
 name = "jinja2"
 version = "2.11.3"
 description = "A very fast and expressive template engine."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -684,7 +676,7 @@ testing = ["coverage", "pyyaml"]
 name = "markupsafe"
 version = "1.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
@@ -922,7 +914,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "prefect"
-version = "0.14.16"
+version = "0.14.17"
 description = "The Prefect Core automation and scheduling engine."
 category = "main"
 optional = false
@@ -953,11 +945,11 @@ urllib3 = ">=1.24.3"
 
 [package.extras]
 airtable = ["airtable-python-wrapper (>=0.11,<0.12)"]
-all_extras = ["airtable-python-wrapper (>=0.11,<0.12)", "boto3 (>=1.9,<2.0)", "azure-storage-blob (>=12.1.0,<13.0)", "azureml-sdk (>=1.0.65,<1.1)", "azure-cosmos (>=3.1.1,<3.2)", "atlassian-python-api (>=2.0.1)", "dask-cloudprovider[aws] (>=0.2.0)", "black", "graphviz (>=0.8)", "jinja2 (>=2.0,<3.0)", "mypy (>=0.600,<0.813)", "Pygments (>=2.2,<3.0)", "pytest (>=5.0)", "testfixtures (>=6.10.3)", "pytest-env (>=0.6.0)", "pytest-xdist (>=1.23)", "dropbox (>=9.0,<10.0)", "great-expectations (>=0.11.1)", "google-cloud-bigquery (>=1.6.0,<2.0)", "google-cloud-storage (>=1.13,<2.0)", "PyGithub (>=1.51,<2.0)", "python-gitlab (>=2.5.0,<3.0)", "gspread (>=3.6.0)", "jira (>=2.0.0)", "papermill (>=2.2.0)", "nbconvert (>=6.0.7)", "dask-kubernetes (>=0.8.0)", "kubernetes (>=9.0.0a1,<=11.0.0b2)", "pandas (>=1.0.1)", "psycopg2-binary (>=2.8.2)", "pymysql (>=0.9.3)", "pyodbc (>=4.0.30)", "pushbullet.py (>=0.11.0)", "redis (>=3.2.1)", "feedparser (>=5.0.1,<6.0)", "snowflake-connector-python (>=1.8.2,<2.5)", "spacy (>=2.0.0,<3.0.0)", "graphviz (>=0.8.3)", "tweepy (>=3.5,<4.0)", "pyarrow (>=0.15.1)", "pyexasol (>=0.16.1)", "soda-sql (>=2.0.0b25)"]
-all_orchestration_extras = ["boto3 (>=1.9,<2.0)", "azure-storage-blob (>=12.1.0,<13.0)", "atlassian-python-api (>=2.0.1)", "google-cloud-storage (>=1.13,<2.0)", "PyGithub (>=1.51,<2.0)", "python-gitlab (>=2.5.0,<3.0)", "kubernetes (>=9.0.0a1,<=11.0.0b2)"]
+all_extras = ["airtable-python-wrapper (>=0.11,<0.12)", "boto3 (>=1.9,<2.0)", "azure-storage-blob (>=12.1.0,<13.0)", "azureml-sdk (>=1.0.65,<1.1)", "azure-cosmos (>=3.1.1,<3.2)", "atlassian-python-api (>=2.0.1)", "dask-cloudprovider[aws] (>=0.2.0)", "black", "graphviz (>=0.8)", "jinja2 (>=2.0,<3.0)", "mypy (>=0.600,<0.813)", "Pygments (>=2.2,<3.0)", "pytest (>=5.0)", "testfixtures (>=6.10.3)", "pytest-env (>=0.6.0)", "pytest-xdist (>=1.23)", "dropbox (>=9.0,<10.0)", "great-expectations (>=0.11.1)", "google-cloud-bigquery (>=1.6.0,<2.0)", "google-cloud-storage (>=1.13,<2.0)", "dulwich (>=0.19.7)", "PyGithub (>=1.51,<2.0)", "python-gitlab (>=2.5.0,<3.0)", "gspread (>=3.6.0)", "jira (>=2.0.0)", "papermill (>=2.2.0)", "nbconvert (>=6.0.7)", "dask-kubernetes (>=0.8.0)", "kubernetes (>=9.0.0a1,<=11.0.0b2)", "pandas (>=1.0.1)", "psycopg2-binary (>=2.8.2)", "pymysql (>=0.9.3)", "pyodbc (>=4.0.30)", "pushbullet.py (>=0.11.0)", "redis (>=3.2.1)", "feedparser (>=5.0.1,<6.0)", "snowflake-connector-python (>=1.8.2,<2.5)", "spacy (>=2.0.0,<3.0.0)", "graphviz (>=0.8.3)", "tweepy (>=3.5,<4.0)", "pyarrow (>=0.15.1)", "pyexasol (>=0.16.1)", "soda-sql (>=2.0.0b25)"]
+all_orchestration_extras = ["boto3 (>=1.9,<2.0)", "azure-storage-blob (>=12.1.0,<13.0)", "atlassian-python-api (>=2.0.1)", "google-cloud-storage (>=1.13,<2.0)", "dulwich (>=0.19.7)", "PyGithub (>=1.51,<2.0)", "python-gitlab (>=2.5.0,<3.0)", "kubernetes (>=9.0.0a1,<=11.0.0b2)"]
 aws = ["boto3 (>=1.9,<2.0)"]
 azure = ["azure-storage-blob (>=12.1.0,<13.0)", "azureml-sdk (>=1.0.65,<1.1)", "azure-cosmos (>=3.1.1,<3.2)"]
-base_library_ci = ["boto3 (>=1.9,<2.0)", "azure-storage-blob (>=12.1.0,<13.0)", "atlassian-python-api (>=2.0.1)", "google-cloud-storage (>=1.13,<2.0)", "PyGithub (>=1.51,<2.0)", "python-gitlab (>=2.5.0,<3.0)", "kubernetes (>=9.0.0a1,<=11.0.0b2)", "black", "graphviz (>=0.8)", "jinja2 (>=2.0,<3.0)", "mypy (>=0.600,<0.813)", "Pygments (>=2.2,<3.0)", "pytest (>=5.0)", "testfixtures (>=6.10.3)", "pytest-env (>=0.6.0)", "pytest-xdist (>=1.23)", "pandas (>=1.0.1)", "jira (>=2.0.0)"]
+base_library_ci = ["boto3 (>=1.9,<2.0)", "azure-storage-blob (>=12.1.0,<13.0)", "atlassian-python-api (>=2.0.1)", "google-cloud-storage (>=1.13,<2.0)", "dulwich (>=0.19.7)", "PyGithub (>=1.51,<2.0)", "python-gitlab (>=2.5.0,<3.0)", "kubernetes (>=9.0.0a1,<=11.0.0b2)", "black", "graphviz (>=0.8)", "jinja2 (>=2.0,<3.0)", "mypy (>=0.600,<0.813)", "Pygments (>=2.2,<3.0)", "pytest (>=5.0)", "testfixtures (>=6.10.3)", "pytest-env (>=0.6.0)", "pytest-xdist (>=1.23)", "pandas (>=1.0.1)", "jira (>=2.0.0)"]
 bitbucket = ["atlassian-python-api (>=2.0.1)"]
 dask_cloudprovider = ["dask-cloudprovider[aws] (>=0.2.0)"]
 dev = ["black", "graphviz (>=0.8)", "jinja2 (>=2.0,<3.0)", "mypy (>=0.600,<0.813)", "Pygments (>=2.2,<3.0)", "pytest (>=5.0)", "testfixtures (>=6.10.3)", "pytest-env (>=0.6.0)", "pytest-xdist (>=1.23)"]
@@ -966,6 +958,7 @@ dropbox = ["dropbox (>=9.0,<10.0)"]
 exasol = ["pyexasol (>=0.16.1)"]
 gcp = ["google-cloud-bigquery (>=1.6.0,<2.0)", "google-cloud-storage (>=1.13,<2.0)"]
 ge = ["great-expectations (>=0.11.1)"]
+git = ["dulwich (>=0.19.7)"]
 github = ["PyGithub (>=1.51,<2.0)"]
 gitlab = ["python-gitlab (>=2.5.0,<3.0)"]
 google = ["google-cloud-bigquery (>=1.6.0,<2.0)", "google-cloud-storage (>=1.13,<2.0)"]
@@ -983,7 +976,7 @@ snowflake = ["snowflake-connector-python (>=1.8.2,<2.5)"]
 sodasql = ["soda-sql (>=2.0.0b25)"]
 spacy = ["spacy (>=2.0.0,<3.0.0)"]
 sql_server = ["pyodbc (>=4.0.30)"]
-task_library_ci = ["airtable-python-wrapper (>=0.11,<0.12)", "boto3 (>=1.9,<2.0)", "azure-storage-blob (>=12.1.0,<13.0)", "azureml-sdk (>=1.0.65,<1.1)", "azure-cosmos (>=3.1.1,<3.2)", "atlassian-python-api (>=2.0.1)", "black", "graphviz (>=0.8)", "jinja2 (>=2.0,<3.0)", "mypy (>=0.600,<0.813)", "Pygments (>=2.2,<3.0)", "pytest (>=5.0)", "testfixtures (>=6.10.3)", "pytest-env (>=0.6.0)", "pytest-xdist (>=1.23)", "dropbox (>=9.0,<10.0)", "great-expectations (>=0.11.1)", "google-cloud-bigquery (>=1.6.0,<2.0)", "google-cloud-storage (>=1.13,<2.0)", "PyGithub (>=1.51,<2.0)", "python-gitlab (>=2.5.0,<3.0)", "gspread (>=3.6.0)", "jira (>=2.0.0)", "papermill (>=2.2.0)", "nbconvert (>=6.0.7)", "dask-kubernetes (>=0.8.0)", "kubernetes (>=9.0.0a1,<=11.0.0b2)", "pandas (>=1.0.1)", "psycopg2-binary (>=2.8.2)", "pymysql (>=0.9.3)", "pushbullet.py (>=0.11.0)", "redis (>=3.2.1)", "feedparser (>=5.0.1,<6.0)", "snowflake-connector-python (>=1.8.2,<2.5)", "spacy (>=2.0.0,<3.0.0)", "graphviz (>=0.8.3)", "tweepy (>=3.5,<4.0)", "pyarrow (>=0.15.1)", "pyexasol (>=0.16.1)", "soda-sql (>=2.0.0b25)"]
+task_library_ci = ["airtable-python-wrapper (>=0.11,<0.12)", "boto3 (>=1.9,<2.0)", "azure-storage-blob (>=12.1.0,<13.0)", "azureml-sdk (>=1.0.65,<1.1)", "azure-cosmos (>=3.1.1,<3.2)", "atlassian-python-api (>=2.0.1)", "black", "graphviz (>=0.8)", "jinja2 (>=2.0,<3.0)", "mypy (>=0.600,<0.813)", "Pygments (>=2.2,<3.0)", "pytest (>=5.0)", "testfixtures (>=6.10.3)", "pytest-env (>=0.6.0)", "pytest-xdist (>=1.23)", "dropbox (>=9.0,<10.0)", "great-expectations (>=0.11.1)", "google-cloud-bigquery (>=1.6.0,<2.0)", "google-cloud-storage (>=1.13,<2.0)", "dulwich (>=0.19.7)", "PyGithub (>=1.51,<2.0)", "python-gitlab (>=2.5.0,<3.0)", "gspread (>=3.6.0)", "jira (>=2.0.0)", "papermill (>=2.2.0)", "nbconvert (>=6.0.7)", "dask-kubernetes (>=0.8.0)", "kubernetes (>=9.0.0a1,<=11.0.0b2)", "pandas (>=1.0.1)", "psycopg2-binary (>=2.8.2)", "pymysql (>=0.9.3)", "pushbullet.py (>=0.11.0)", "redis (>=3.2.1)", "feedparser (>=5.0.1,<6.0)", "snowflake-connector-python (>=1.8.2,<2.5)", "spacy (>=2.0.0,<3.0.0)", "graphviz (>=0.8.3)", "tweepy (>=3.5,<4.0)", "pyarrow (>=0.15.1)", "pyexasol (>=0.16.1)", "soda-sql (>=2.0.0b25)"]
 templates = ["jinja2 (>=2.0,<3.0)"]
 test = ["pytest (>=5.0)", "testfixtures (>=6.10.3)", "pytest-env (>=0.6.0)", "pytest-xdist (>=1.23)"]
 twitter = ["tweepy (>=3.5,<4.0)"]
@@ -1115,28 +1108,6 @@ description = "Persistent/Functional/Immutable data structures"
 category = "dev"
 optional = false
 python-versions = ">=3.5"
-
-[[package]]
-name = "pyserde"
-version = "0.2.2"
-description = "Serialization library on top of dataclasses."
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-dataclasses = "*"
-jinja2 = "*"
-stringcase = "*"
-toml = {version = "*", optional = true, markers = "extra == \"toml\""}
-typing-inspect = ">=0.4.0"
-
-[package.extras]
-all = ["msgpack", "toml", "pyyaml"]
-msgpack = ["msgpack"]
-test = ["coverage", "pytest", "pytest-cov", "pytest-flake8", "mypy", "flake8"]
-toml = ["toml"]
-yaml = ["pyyaml"]
 
 [[package]]
 name = "pytest"
@@ -1316,22 +1287,21 @@ google-cloud-core = "^1.3.0"
 google-cloud-storage = "^1.30.0"
 ndjson = "^0.3.1"
 pyarrow = "^3.0.0"
-pyserde = {version = "^0.2.0", extras = ["toml"]}
+python-box = "^5.3.0"
 requests = "^2.24.0"
 toml = "^0.10.2"
-tomlkit = "^0.7.0"
 
 [package.source]
 type = "git"
 url = "https://github.com/dataverbinders/statline-bq.git"
 reference = "master"
-resolved_reference = "d27a11b939938e29c97a78361d65918e6d7f2ec0"
+resolved_reference = "8c823c4c51e84aa1ac97c0c3710f7f32264760b4"
 
 [[package]]
 name = "stringcase"
 version = "1.2.0"
 description = "String case converter."
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -1374,7 +1344,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "tomlkit"
 version = "0.7.0"
 description = "Style preserving TOML library"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -1420,7 +1390,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.7.4.3"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -1428,7 +1398,7 @@ python-versions = "*"
 name = "typing-inspect"
 version = "0.6.0"
 description = "Runtime inspection utilities for typing module."
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -1542,8 +1512,8 @@ bunch = [
     {file = "bunch-1.0.1.zip", hash = "sha256:3c554816ba260634b55c1edf8de6467d8122dbd18ec20f323e181869bc48ac93"},
 ]
 cachetools = [
-    {file = "cachetools-4.2.1-py3-none-any.whl", hash = "sha256:1d9d5f567be80f7c07d765e21b814326d78c61eb0c3a637dffc0e5d1796cb2e2"},
-    {file = "cachetools-4.2.1.tar.gz", hash = "sha256:f469e29e7aa4cff64d8de4aad95ce76de8ea1125a16c68e0d93f65c3c3dc92e9"},
+    {file = "cachetools-4.2.2-py3-none-any.whl", hash = "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001"},
+    {file = "cachetools-4.2.2.tar.gz", hash = "sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff"},
 ]
 cbsodata = [
     {file = "cbsodata-1.3.4-py3-none-any.whl", hash = "sha256:6b304cb4fe91e42e6fe022eacafde37de01732d153b3edf82ae9e034f9b80415"},
@@ -1613,24 +1583,20 @@ croniter = [
     {file = "croniter-0.3.37.tar.gz", hash = "sha256:12ced475dfc107bf7c6c1440af031f34be14cd97bbbfaf0f62221a9c11e86404"},
 ]
 dask = [
-    {file = "dask-2021.4.0-py3-none-any.whl", hash = "sha256:2370e4d7da35ee49e2211aef8ab63832455f25588149ca8b41d2c984c747e7cc"},
-    {file = "dask-2021.4.0.tar.gz", hash = "sha256:4f7e52ddedbffdf1cfd5525f4f901689e45f8769e059e7b7ecb332f8496f7f34"},
-]
-dataclasses = [
-    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
-    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
+    {file = "dask-2021.4.1-py3-none-any.whl", hash = "sha256:344c342d699466c3f742019b7a33caf2472b751f38370b200ede7d2f354aa1e4"},
+    {file = "dask-2021.4.1.tar.gz", hash = "sha256:195e4eeb154222ea7a1c368119b5f321ee4ec9d78531471fe0145a527f744aa8"},
 ]
 dataclasses-json = [
-    {file = "dataclasses-json-0.5.2.tar.gz", hash = "sha256:56ec931959ede74b5dedf65cf20772e6a79764d20c404794cce0111c88c085ff"},
-    {file = "dataclasses_json-0.5.2-py3-none-any.whl", hash = "sha256:b746c48d9d8e884e2a0ffa59c6220a1b21f94d4f9f12c839da0a8a0efd36dc19"},
+    {file = "dataclasses-json-0.5.3.tar.gz", hash = "sha256:fe17da934cfc4ec792ebe7e9a303434ecf4f5f8d8a7705acfbbe7ccbd34bf1ae"},
+    {file = "dataclasses_json-0.5.3-py3-none-any.whl", hash = "sha256:740e7b564d72ddaa0f66406b4ecb799447afda2799c1c425a4a76151bfcfda50"},
 ]
 decorator = [
     {file = "decorator-5.0.7-py3-none-any.whl", hash = "sha256:945d84890bb20cc4a2f4a31fc4311c0c473af65ea318617f13a7257c9a58bc98"},
     {file = "decorator-5.0.7.tar.gz", hash = "sha256:6f201a6c4dac3d187352661f508b9364ec8091217442c9478f1f83c003a0f060"},
 ]
 distributed = [
-    {file = "distributed-2021.4.0-py3-none-any.whl", hash = "sha256:44618b7682d36496efcc8230f817d3b99432935fab475513be0c707fcf26c837"},
-    {file = "distributed-2021.4.0.tar.gz", hash = "sha256:7af2b77819a162d8f5973fb015be5a1641f47901d2e254409dafa2d7fcc3fce6"},
+    {file = "distributed-2021.4.1-py3-none-any.whl", hash = "sha256:fe0e005e9aa79d68e185008bd2ce6562388311efd1c59a04ab6127ee631b8808"},
+    {file = "distributed-2021.4.1.tar.gz", hash = "sha256:4c1b189ec5aeaf770c473f730f4a3660dc655601abd22899e8a0662303662168"},
 ]
 docker = [
     {file = "docker-5.0.0-py2.py3-none-any.whl", hash = "sha256:fc961d622160e8021c10d1bcabc388c57d55fb1f917175afbe24af442e6879bd"},
@@ -1653,8 +1619,8 @@ google-api-core = [
     {file = "google_api_core-1.26.3-py2.py3-none-any.whl", hash = "sha256:099762d4b4018cd536bcf85136bf337957da438807572db52f21dc61251be089"},
 ]
 google-auth = [
-    {file = "google-auth-1.29.0.tar.gz", hash = "sha256:010f011c4e27d3d5eb01106fba6aac39d164842dfcd8709955c4638f5b11ccf8"},
-    {file = "google_auth-1.29.0-py2.py3-none-any.whl", hash = "sha256:f30a672a64d91cc2e3137765d088c5deec26416246f7a9e956eaf69a8d7ed49c"},
+    {file = "google-auth-1.30.0.tar.gz", hash = "sha256:9ad25fba07f46a628ad4d0ca09f38dcb262830df2ac95b217f9b0129c9e42206"},
+    {file = "google_auth-1.30.0-py2.py3-none-any.whl", hash = "sha256:588bdb03a41ecb4978472b847881e5518b5d9ec6153d3d679aa127a55e13b39f"},
 ]
 google-cloud-bigquery = [
     {file = "google-cloud-bigquery-1.28.0.tar.gz", hash = "sha256:9784cff71d6a46ce202748169f9c7e38fc99d6babbb2f3cdc540475d11f572b9"},
@@ -1665,8 +1631,8 @@ google-cloud-core = [
     {file = "google_cloud_core-1.6.0-py2.py3-none-any.whl", hash = "sha256:40d9c2da2d03549b5ac3dcccf289d4f15e6d1210044c6381ce45c92913e62904"},
 ]
 google-cloud-storage = [
-    {file = "google-cloud-storage-1.37.1.tar.gz", hash = "sha256:e06a4797c87ac73c4a74801539fdf0a91761c3014281ff58b7b29f15b34c206e"},
-    {file = "google_cloud_storage-1.37.1-py2.py3-none-any.whl", hash = "sha256:63a9dab155bf81c51354db3d11f3e83a1db7d58eff453f1ce51ffa565d32617b"},
+    {file = "google-cloud-storage-1.38.0.tar.gz", hash = "sha256:162011d66f64b8dc5d7936609a5daf0066cc521231546aea02c126a5559446c4"},
+    {file = "google_cloud_storage-1.38.0-py2.py3-none-any.whl", hash = "sha256:69499560ec8234339ce831704419a2288c409a422f6e9ed1facc9345412ee637"},
 ]
 google-crc32c = [
     {file = "google-crc32c-1.1.2.tar.gz", hash = "sha256:dff5bd1236737f66950999d25de7a78144548ebac7788d30ada8c1b6ead60b27"},
@@ -2033,8 +1999,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 prefect = [
-    {file = "prefect-0.14.16-py3-none-any.whl", hash = "sha256:8b432299ad4f39100231ed95ce178e4e6d2bbc46472875e1e2d2e13588670979"},
-    {file = "prefect-0.14.16.tar.gz", hash = "sha256:ff9181dcef2aff5164d3848cc4d94d318e4f472d726b38f82a69ea30acc79c6d"},
+    {file = "prefect-0.14.17-py3-none-any.whl", hash = "sha256:3796992dbacdc4b7daee9c39df47c7ade5d9ba804273994dfec205cae5a56a21"},
+    {file = "prefect-0.14.17.tar.gz", hash = "sha256:fe2900d06bc80d904c89b29bc3c6fd8a88e8fd3814968cccb8306932c14e4a05"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.18-py3-none-any.whl", hash = "sha256:bf00f22079f5fadc949f42ae8ff7f05702826a97059ffcc6281036ad40ac6f04"},
@@ -2175,10 +2141,6 @@ pyparsing = [
 ]
 pyrsistent = [
     {file = "pyrsistent-0.17.3.tar.gz", hash = "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"},
-]
-pyserde = [
-    {file = "pyserde-0.2.2-py3-none-any.whl", hash = "sha256:bef911d6223c7aa4ad697b791e99d01b871a972876eb2cc01aad9a80f8debb4a"},
-    {file = "pyserde-0.2.2.tar.gz", hash = "sha256:a132e8ffef59ac8be6012c6df5ddf13d53f8cc110bb920cb0530f339f0527423"},
 ]
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},


### PR DESCRIPTION
This PR:

* Conforms the `nl-open-data` config to the modified config in `statline-bq` (see [this PR](https://github.com/dataverbinders/statline-bq/pull/69)).
  * This separates out config object from prefect's config object - solving the issue of having to run the import `from nl_open_data.config import config` before any Prefect imports, and allowing us to neatly conform to PEP-8 again.
  * It **does not** solve issue #85, unfortunatley.
* Adds `get_wrap` task.